### PR TITLE
[README]: fix orthographic mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 6.  Your help with a election is needed. Given list of candidates, where each element has Candidate.class type.
     Check which candidates are eligible to apply for president position and return their names sorted alphabetically.
     The requirements are: person should be at least 35 years old, should be allowed to vote, have nationality - 'Ukrainian'
-    and live in urk for 10 years. For the last requirement use field periodsInUkr, which has following view:
+    and live in Ukraine for 10 years. For the last requirement use field periodsInUkr, which has following view:
     "2002-2015" For now we don't care if that was last 10 or not. We want to reuse our validation in future, so
     let's write our own impl of Predicate<Candidate> in CandidateValidator.
 


### PR DESCRIPTION
Fixed mistake in README file.
![image](https://user-images.githubusercontent.com/96740815/175494718-d87c1b99-7800-4893-9345-4e5d78a1e16a.png)
